### PR TITLE
Change Color of Button For SignIn and SignUp #14

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -55,3 +55,4 @@ body {
 .auth-button {
   @apply w-full px-4 py-3 rounded bg-primary text-white font-semibold hover:bg-primary-hover transition-colors shadow-sm hover:shadow disabled:opacity-50 disabled:cursor-not-allowed;
 }
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,8 +19,9 @@ module.exports = {
       },
       colors: {
         primary: {
-          DEFAULT: "#4F46E5",
-          hover: "#4338CA",
+          DEFAULT: "#dc2626",   // 🔴 Red (base)
+          hover: "#b91c1c",     // 🔴 Dark Red (hover)
+          light: "#fca5a5",     // 🔴 Light Red (optional)
         },
         secondary: {
           DEFAULT: "#6B7280",


### PR DESCRIPTION
Issue Resolved : #14 

UI buttons:  red → dark red on hover → light red variant globally
1. Update tailwind.config.js
Added custom red shades:
// tailwind.config.js
          DEFAULT: "#dc2626",   // red-600 (default button color)
          hover: "#b91c1c",     // red-700 (hover color)
          light: "#fca5a5",     // red-300 (optional light variant)
   
2. Updated CSS 
Change .auth-button to:
.auth-button {
  @apply w-full px-4 py-3 rounded bg-primary text-white font-semibold hover:bg-primary-hover transition-colors shadow-sm hover:shadow disabled:opacity-50 disabled:cursor-not-allowed;
}


✅ Now:
* Default button → red (#dc2626)
* Hover → dark red (#b91c1c)
* Light red variant (primary-light)