### PR TITLE
Add password visibility toggle to signin and signup forms

### DIFF
--- a/public/Sign Up.tsx
+++ b/public/Sign Up.tsx
@@ -1,7 +1,8 @@
 // SignUpForm.tsx
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function SignUpForm({ onSignUp }) {
+  const [showPassword, setShowPassword] = useState(false);
   return (
     <div className="signup-page" style={{
       display: 'flex', flexDirection: 'column', alignItems: 'center',
@@ -35,11 +36,28 @@ export default function SignUpForm({ onSignUp }) {
               width: '100%', padding: '10px', marginBottom: '14px', borderRadius: '8px',
               border: '1px solid #d0d0d0'
             }} />
-          <input type="password" placeholder="Password" required
-            style={{
-              width: '100%', padding: '10px', marginBottom: '10px', borderRadius: '8px',
-              border: '1px solid #d0d0d0'
-            }} />
+          <div style={{ position: 'relative', marginBottom: '10px' }}>
+            <input
+              type={showPassword ? "text" : "password"}
+              placeholder="Password"
+              required
+              style={{
+                width: '100%', padding: '10px', borderRadius: '8px',
+                border: '1px solid #d0d0d0', paddingRight: '40px'
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? "Hide password" : "Show password"}
+              style={{
+                position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)',
+                cursor: 'pointer', fontSize: '16px', background: 'none', border: 'none'
+              }}
+            >
+              {showPassword ? "🙈" : "👁️"}
+            </button>
+          </div>
           <button type="submit" style={{
             background: '#283e4a', color: '#fff', fontWeight: 'bold', borderRadius: '8px',
             border: 'none', padding: '12px', width: '100%', fontSize: '18px'

--- a/src/SignInForm.tsx
+++ b/src/SignInForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 export function SignInForm() {
+  const [showPassword, setShowPassword] = useState(false);
   const { signIn } = useAuthActions();
   const [flow, setFlow] = useState<"signIn" | "signUp">("signIn");
   const [submitting, setSubmitting] = useState(false);
@@ -39,13 +40,33 @@ export function SignInForm() {
           placeholder="Email"
           required
         />
-        <input
-          className="auth-input-field"
-          type="password"
-          name="password"
-          placeholder="Password"
-          required
-        />
+        <div style={{ position: "relative" }}>
+          <input
+            className="auth-input-field"
+            type={showPassword ? "text" : "password"}
+            name="password"
+            placeholder="Password"
+            required
+            style={{ paddingRight: "40px" }}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            style={{
+              position: "absolute",
+              right: "10px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              cursor: "pointer",
+              fontSize: "16px",
+              background: "none",
+              border: "none",
+            }}
+          >
+            {showPassword ? "🙈" : "👁️"}
+          </button>
+        </div>
         <button className="auth-button" type="submit" disabled={submitting}>
           {flow === "signIn" ? "Sign in" : "Sign up"}
         </button>


### PR DESCRIPTION
## 🔒 Add Password Visibility Toggle to Authentication Forms

### Description
This PR adds a password visibility toggle feature to both signin and signup forms, allowing users to show/hide their password input for better user experience.

### Changes Made
- ✅ Added password toggle functionality to SignInForm component
- ✅ Enhanced user experience with show/hide password feature
- ✅ Consistent implementation across both auth forms  
- ✅ Uses emoji icons (👁️/🙈) for better compatibility

### Features
- **Show/Hide Password**: Click the eye icon to toggle password visibility
- **Consistent Design**: Same implementation across both forms
- **No Dependencies**: Uses emoji icons, no additional libraries needed
- **Accessibility**: Clear visual indicators for password state

### Testing
- [ ] Password toggle works in signin form
- [ ] Password toggle works in signup form
- [ ] Form submission functionality preserved
- [ ] Visual design matches existing UI

**Note**: This PR was created without local testing. Please verify functionality during review.